### PR TITLE
support msgpack format

### DIFF
--- a/src/kave/format.cr
+++ b/src/kave/format.cr
@@ -1,9 +1,13 @@
 module Kave
   class Format
-    MAPPING = {json: json}
+    MAPPING = {json: json, msgpack: msgpack}
 
     def self.json
       {"content_type" => "application/json", "extension" => ".json"}
+    end
+
+    def self.msgpack
+      {"content_type" => "application/msgpack"}
     end
 
     def jsonize(obj)


### PR DESCRIPTION
If using `:msgpack` as a format this error is raised `Exception: Missing named tuple key: :msgpack (KeyError)`

this pr adds msgpack as a format


    Kave.configure do |c|
      c.format = :msgpack
    end